### PR TITLE
[Fix] 대관현황 중복 제거 시 `id` 가 아니라 `start`를 이용하도록 변경

### DIFF
--- a/electron/src/utils/getUpcomingWeeklyReservation.ts
+++ b/electron/src/utils/getUpcomingWeeklyReservation.ts
@@ -40,7 +40,7 @@ export const getUpcomingWeeklyReservation = async (
 
   page.close();
 
-  const deduplicated_reservations = uniqueBy(reservations, (reservation) => reservation.id);
+  const deduplicated_reservations = uniqueBy(reservations, (reservation) => reservation.start);
 
   const parsedReservations = deduplicated_reservations.map((reservation) => {
     const start_number = parseInt(reservation.start, 10) * 1000;

--- a/electron/src/utils/groupReservationsByDate.ts
+++ b/electron/src/utils/groupReservationsByDate.ts
@@ -1,7 +1,6 @@
 import { ParsedReservation, Reservation } from "../types";
 
 const groupReservationsByDate = <T extends ParsedReservation>(arr: T[]) => {
-  console.log(arr);
   return arr.reduce<Array<{ date: string; reservations: T[] }>>((groups, reservation) => {
     const target_date = reservation.date;
 


### PR DESCRIPTION
### What
- fixes #50.

### How
- 예약 현황 데이터의 `id` 값이 유니크한 값이 아니었음(?!) → 동일 강의의 경우 동일한 `id`를 사용하는 것으로 추정됨
- 따라서 대관 시작시간인 `start` 값을 기준으로 deduplication을 진행하도록 코드 수정

### Reference

