### PR TITLE
feat: Replace constant lectureRoomList with API response

### DIFF
--- a/frontend/src/apis/index.ts
+++ b/frontend/src/apis/index.ts
@@ -5,6 +5,10 @@ const YSSApi = {
     const res = await window.YonseiSpaceSystem.login(data.id, data.pw);
     return res;
   },
+  async getBuildingRoomList() {
+    const res = await window.YonseiSpaceSystem.getBuildingRoomList();
+    return res;
+  },
   async getReservations(data: GetReservationForm) {
     const res = await window.YonseiSpaceSystem.getRoomReservations(
       data.building_uid,

--- a/frontend/src/atom.ts
+++ b/frontend/src/atom.ts
@@ -1,6 +1,10 @@
 import { atom, selector } from 'recoil';
 import YSSApi from './apis';
-import { ReservationsPerDay, GetReservationForm } from './interfaces/index';
+import {
+  ReservationsPerDay,
+  GetReservationForm,
+  LectureRoomsPerBuilding,
+} from './interfaces/index';
 import {
   findUpcomingSaturdays,
   queryReservationsOnSpecificDates,
@@ -45,8 +49,17 @@ const reservationStatusState = selector<ReservationsPerDay[] | null>({
   },
 });
 
+const lectureRoomsListState = selector<LectureRoomsPerBuilding[]>({
+  key: 'lectureRoomsListState',
+  get: async () => {
+    const res = await YSSApi.getBuildingRoomList();
+    return res;
+  },
+});
+
 export {
   isLoginCompletedState,
   lectureRoomChoiceState,
   reservationStatusState,
+  lectureRoomsListState,
 };

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 import SidebarItem from './SidebarItem';
-import { LectureRoomList } from '../constants';
+import { lectureRoomsListState } from '../atom';
 
 function Sidebar() {
+  const lectureRoomsList = useRecoilValue(lectureRoomsListState);
   return (
     <ul>
-      {LectureRoomList.map((item) => (
+      {lectureRoomsList.map((item) => (
         <SidebarItem data={item} key={item.building_name} isMainMenu>
           {item.rooms}
         </SidebarItem>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,44 +1,6 @@
-import { LectureRoomsPerBuilding } from './interfaces/index';
-
-export const timeslotsArr = Array(32)
+/* eslint-disable import/prefer-default-export */
+const timeslotsArr = Array(32)
   .fill(0)
   .map((v, i) => i);
 
-export const LectureRoomList: LectureRoomsPerBuilding[] = [
-  {
-    building_name: '제 1공학관',
-    building_uid: 102,
-    rooms: [
-      {
-        room_name: 'A320',
-        room_uid: 555,
-      },
-      {
-        room_name: 'A546',
-        room_uid: 704,
-      },
-    ],
-  },
-  {
-    building_name: '제 4공학관',
-    building_uid: 124,
-    rooms: [
-      {
-        room_name: 'D403',
-        room_uid: 14151,
-      },
-      {
-        room_name: 'D404',
-        room_uid: 14152,
-      },
-      {
-        room_name: 'D503',
-        room_uid: 14158,
-      },
-      {
-        room_name: 'D504',
-        room_uid: 14159,
-      },
-    ],
-  },
-];
+export { timeslotsArr };

--- a/frontend/src/pages/Main/MainPage.tsx
+++ b/frontend/src/pages/Main/MainPage.tsx
@@ -20,7 +20,9 @@ function MainPage() {
 
   return (
     <div className={cx('container')}>
-      <Sidebar />
+      <React.Suspense>
+        <Sidebar />
+      </React.Suspense>
       <div>
         <React.Suspense>
           <ReservationInfoTable />

--- a/frontend/src/types/index.d.ts
+++ b/frontend/src/types/index.d.ts
@@ -1,5 +1,8 @@
 import { BuildingUID, RoomUID } from '../types';
-import { ReservationsPerDay } from '../interfaces/index';
+import {
+  LectureRoomsPerBuilding,
+  ReservationsPerDay,
+} from '../interfaces/index';
 /* eslint-disable no-unused-vars */
 export {};
 
@@ -7,6 +10,7 @@ declare global {
   interface Window {
     YonseiSpaceSystem: {
       login: (id: string, pw: string) => Promise<boolean>;
+      getBuildingRoomList: () => Promise<LectureRoomsPerBuilding[]>;
       getRoomReservations: (
         building_uid: BuildingUID,
         room_uid: RoomUID,


### PR DESCRIPTION
### What
closes #52 

* 조회 가능한 강의실 목록을 `lectureRoomsListState`selector로 관리
* `getBuildingRoomList` API 연동

### Why


### How

### Reference

